### PR TITLE
Include license in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md
+include README.md LICENSE


### PR DESCRIPTION
It is important for the license file to be included in sdists for legal reasons.