### PR TITLE
Update doe_factorial.fractfact

### DIFF
--- a/pyDOE2/doe_factorial.py
+++ b/pyDOE2/doe_factorial.py
@@ -198,7 +198,7 @@ def fracfact(gen):
 
     """
     # Recognize letters and combinations
-    A = [item for item in re.split('\-?\s?\+?', gen) if item]  # remove empty strings
+    A = [item for item in re.split('\-|\s|\+', gen) if item]  # remove empty strings
     C = [len(item) for item in A]
 
     # Indices of single letters (main factors)


### PR DESCRIPTION
in the doe_factorial.fractfact, there is an issue with re.split (occurring in Python3.7)
Namely, string 201 should be replaced with:
    A = [item for item in re.split('\-|\s|\+', gen) if item]  # remove empty strings