### PR TITLE
Cleanup of imports

### DIFF
--- a/pyDOE2/doe_factorial.py
+++ b/pyDOE2/doe_factorial.py
@@ -17,7 +17,6 @@ import itertools
 import math
 import re
 import string
-from itertools import dropwhile, combinations, islice
 
 import numpy as np
 from scipy.special import binom
@@ -307,7 +306,7 @@ def fracfact_by_res(n, res):
         ValueError: design not possible
     """
     # Determine minimum required number of base-factors.
-    min_fac = next(dropwhile(lambda n_: _n_fac_at_res(n_, res) < n,
+    min_fac = next(itertools.dropwhile(lambda n_: _n_fac_at_res(n_, res) < n,
                              range(res - 1, n)), None)
 
     if min_fac is None:
@@ -324,8 +323,8 @@ def fracfact_by_res(n, res):
 
     # Fill out with factor combinations until `n` factors.
     factor_combs = (''.join(c) for r in range(res - 1, len(factors))
-                    for c in combinations(factors, r))
-    extra_factors = list(islice(factor_combs, n - len(factors)))
+                    for c in itertools.combinations(factors, r))
+    extra_factors = list(itertools.islice(factor_combs, n - len(factors)))
 
     # Concatenate `gen` string for `fracfact`.
     gen = ' '.join(factors + extra_factors)

--- a/pyDOE2/doe_factorial.py
+++ b/pyDOE2/doe_factorial.py
@@ -13,7 +13,6 @@ Much thanks goes to these individuals. It has been converted to Python by
 Abraham Lee.
 """
 
-import imp
 import itertools
 import math
 import re

--- a/pyDOE2/doe_plackett_burman.py
+++ b/pyDOE2/doe_plackett_burman.py
@@ -13,7 +13,6 @@ Much thanks goes to these individuals. It has been converted to Python by
 Abraham Lee.
 """
 
-import math
 import numpy as np
 from scipy.linalg import toeplitz, hankel
 


### PR DESCRIPTION
This PR
* removes unused imports of `imp` (which is deprecated since Python 3.4) and `math`
* removes duplicate imports of some functions in `itertools`

This does not change the API or the behavior of the library. I am making this pull request (mainly) because of deprecation warnings raised in my test environments.