### PR TITLE
Possible bug, fractional factorial by resolution

### DIFF
--- a/pyDOE2/doe_factorial.py
+++ b/pyDOE2/doe_factorial.py
@@ -309,7 +309,7 @@ def fracfact_by_res(n, res):
     """
     # Determine minimum required number of base-factors.
     min_fac = next(dropwhile(lambda n_: _n_fac_at_res(n_, res) < n,
-                             range(res - 1, n)), None)
+                             range(res - 1, n + 1)), None)
 
     if min_fac is None:
         raise ValueError('design not possible')
@@ -349,7 +349,7 @@ def _n_fac_at_res(n, res):
     """ Calculate number of possible factors for fractional factorial
     design with `n` base factors at resolution `res`.
     """
-    return sum(binom(n, r) for r in range(res - 1, n)) + n
+    return sum(binom(n, r) for r in range(res - 1, n + 1)) + n
 
 ################################################################################
 


### PR DESCRIPTION
Current code claims "no design possible" for fracfact_by_res(5, 5) yet there is a design for this combination according to https://en.wikipedia.org/wiki/Fractional_factorial_design and https://blog.minitab.com/hubfs/Imported_Blog_Media/available_factorial_designs.bmp

I think the discrepancy is because the range doesn't extend to n on the two lines modified.